### PR TITLE
#138 Making command line arguments only honored on initial startup

### DIFF
--- a/client/ClientEntry.gd
+++ b/client/ClientEntry.gd
@@ -16,6 +16,28 @@ func _ready():
 		#go_to_pc_vr()
 		#go_to_mobile_vr()
 		go_to_flat()
+	
+	var playerName = UserData.data.user_name
+	var serverIp = UserData.data.last_ip
+	var serverPort = int(UserData.data.last_port)
+	
+	var args := OS.get_cmdline_args()
+	print("Command Line args: %d" % [args.size()])
+	if (args.size() > 0):
+		for arg in args:
+			print("    : %s" % arg)
+			var keyValuePair = arg.split("=")
+			
+			match keyValuePair[0]:
+				"--name":
+					playerName = keyValuePair[1]
+					# Also override the default file save path so each test user has its own settings.
+					UserData.file_name = 'user://user_data-%s.json' % playerName
+				"--ip":
+					serverIp = keyValuePair[1]
+				_:
+					print("UNKNOWN ARGUMENT %s" % keyValuePair[0])
+		ClientNetwork.join_game(serverIp, serverPort, playerName.strip_edges())
 
 
 func go_to_flat():

--- a/client/main_menu/MainMenu.gd
+++ b/client/main_menu/MainMenu.gd
@@ -34,26 +34,6 @@ func _ready():
 	playerNameInput.text = UserData.data.user_name
 	serverIpInput.text = UserData.data.last_ip
 	serverPortInput.text = str(UserData.data.last_port)
-	
-	var args := OS.get_cmdline_args()
-	print("Command Line args: %d" % [args.size()])
-	if (args.size() > 0):
-		for arg in args:
-			print("    : %s" % arg)
-			var keyValuePair = arg.split("=")
-			
-			match keyValuePair[0]:
-				"--name":
-					playerNameInput.text = keyValuePair[1]
-					# Also override the default file save path so each test user has its own settings.
-					UserData.file_name = 'user://user_data-%s.json' % playerNameInput.text
-				"--ip":
-					serverIpInput.text = keyValuePair[1]
-				_:
-					print("UNKNOWN ARGUMENT %s" % keyValuePair[0])
-	
-	if (args.size() > 0):
-		connect_to_server(playerNameInput.text, serverIpInput.text, int(serverPortInput.text))
 
 
 func _on_ConnectButton_pressed():

--- a/common/game/mode/fugitive/FugitiveGame.gd
+++ b/common/game/mode/fugitive/FugitiveGame.gd
@@ -221,6 +221,7 @@ func process_hiders():
 	var hiders = get_tree().get_nodes_in_group(Hider.GROUP)
 	var lights = get_tree().get_nodes_in_group(Groups.LIGHTS)
 	var cars = get_tree().get_nodes_in_group(Groups.CARS)
+	var winZones := map.get_win_zones()
 	
 	var curPlayerType = GameData.get_current_player_type()
 	
@@ -252,7 +253,11 @@ func process_hiders():
 		
 		for car in cars:
 			car.process_hider(hider)
-
+			
+		for winZone in winZones:
+			# Now, check if this hider is in the win zone.
+			if (winZone.overlaps_body(hider.playerBody)):
+				hider.set_current_visibility(1.0);
 
 func check_win_conditions():
 	# Only the server will end the game

--- a/common/game/mode/fugitive/FugitiveGame.gd
+++ b/common/game/mode/fugitive/FugitiveGame.gd
@@ -256,8 +256,8 @@ func process_hiders():
 			
 		for winZone in winZones:
 			# Now, check if this hider is in the win zone.
-			if (winZone.overlaps_body(hider.playerBody)):
-				hider.set_current_visibility(1.0);
+			if winZone.overlaps_body(hider.playerBody):
+				hider.set_current_visibility(1.0)
 
 func check_win_conditions():
 	# Only the server will end the game


### PR DESCRIPTION
To note, where the change is feels a little weird in there because the MainMenu scene *has to* be initialized before the join game is called, otherwise the per-device-type handling from there down is never initialized and you end up with a blank screen on game join.

I tested it out and it works, but just to note in case it's odd how it initializes the relevant MainMenu scene and then immediately attempts to see if it should call join_game.