### PR TITLE
Feature - Server Repo REST Refactor Compatibility

### DIFF
--- a/addons/LANServerBroadcast/server_listener/ServerListener.gd
+++ b/addons/LANServerBroadcast/server_listener/ServerListener.gd
@@ -99,7 +99,7 @@ func _exit_tree():
 
 
 func request_servers():
-	var endpointUrl = serverRepositoryUrl + "/list"
+	var endpointUrl = serverRepositoryUrl + "/servers"
 	serverRepoRequest.request(endpointUrl)
 
 


### PR DESCRIPTION
# Scope

This PR is the game-client piece to FugitiveTheGame/Fugitive3dServerRepository#18, and updates the URLs and requests to the server repo service to use the new RESTful endpoints.

I've tested everything end-to-end, locally, by running the server repo service with the REST changes, running the game client, and running an exported `Server.exe` with the `--public` flag.

All seemed to work without issue! 😁